### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ jobs:
       - SCIPY_VER="=0.19"
     - python: 3.6
       env:
-      - NUMPY_VER=""
-      - SCIPY_VER=""
+      - NUMPY_VER="1.13"
+      - SCIPY_VER="=1.0.0"
     - python: 3.7
       env:
-      - NUMPY_VER=""
-      - SCIPY_VER=""
+      - NUMPY_VER="1.15"
+      - SCIPY_VER="1.2.0"
     - python: 3.8
       env:
-      - NUMPY_VER=""
-      - SCIPY_VER=""
+      - NUMPY_VER="1.17"
+      - SCIPY_VER="1.4.0"
     - python: 3.9
       env:
       - NUMPY_VER=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-matrix:
+jobs:
   include:
     - python: 2.7
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ jobs:
       - SCIPY_VER="=0.19"
     - python: 3.6
       env:
-      - NUMPY_VER="1.13"
+      - NUMPY_VER="=1.13"
       - SCIPY_VER="=1.0.0"
     - python: 3.7
       env:
-      - NUMPY_VER="1.15"
-      - SCIPY_VER="1.2.0"
+      - NUMPY_VER="=1.15"
+      - SCIPY_VER="=1.2.0"
     - python: 3.8
       env:
-      - NUMPY_VER="1.17"
-      - SCIPY_VER="1.4.0"
+      - NUMPY_VER="=1.17"
+      - SCIPY_VER="=1.4.0"
     - python: 3.9
       env:
       - NUMPY_VER=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - python: 3.8
       env:
       - NUMPY_VER="=1.17"
-      - SCIPY_VER="=1.4.0"
+      - SCIPY_VER="=1.4.1"
     - python: 3.9
       env:
       - NUMPY_VER=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,6 @@ language: python
 
 jobs:
   include:
-    - python: 2.7
-      env:
-      - NUMPY_VER="=1.10"
-      - SCIPY_VER="=0.17"
-    - python: 3.4
-      env:
-      - NUMPY_VER="=1.11"
-      - SCIPY_VER="=0.18"
     - python: 3.5
       env:
       - NUMPY_VER="=1.12"
@@ -18,6 +10,19 @@ jobs:
       env:
       - NUMPY_VER=""
       - SCIPY_VER=""
+    - python: 3.7
+      env:
+      - NUMPY_VER=""
+      - SCIPY_VER=""
+    - python: 3.8
+      env:
+      - NUMPY_VER=""
+      - SCIPY_VER=""
+    - python: 3.9
+      env:
+      - NUMPY_VER=""
+      - SCIPY_VER=""
+
 
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ The main focus of this package is the compound-Poisson behavior,
 specifically where :math:`1 < p < 2`. However, it should be possible to
 calculate the distribution for all the possible values of p.
 
-.. image:: https://travis-ci.org/thequackdaddy/tweedie.png?branch=master
-   :target: https://travis-ci.org/thequackdaddy/tweedie
+.. image:: https://app.travis-ci.com/thequackdaddy/tweedie.svg?branch=master
+   :target: https://app.travis-ci.com/thequackdaddy/tweedie
 
 .. image:: http://codecov.io/github/thequackdaddy/tweedie/coverage.svg?branch=master
    :target: http://codecov.io/github/thequackdaddy/tweedie?branch=master

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ versionfile_source = tweedie/_version.py
 versionfile_build = tweedie/_version.py
 tag_prefix =
 parentdir_prefix = tweedie-
+
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt
+


### PR DESCRIPTION
Looks like there's been a fair amount of changes... python 3.9 fails with most recent scipy. 

